### PR TITLE
Update Readme with custom travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ python:
   - "3.4"
 env:
   - TESTS=fuel
-  - TESTS=blocks
 before_install:
   # Setup Python environment with BLAS libraries
   - wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -24,13 +23,6 @@ before_install:
 install:
   # Install all Python dependencies
   - |
-      if [[ $TESTS == 'blocks' ]]; then
-        curl -O https://raw.githubusercontent.com/mila-udem/blocks/$TRAVIS_BRANCH/req-travis-conda.txt
-        conda install -q --yes python=$TRAVIS_PYTHON_VERSION --file req-travis-conda.txt
-        pip install -r https://raw.githubusercontent.com/mila-udem/blocks/$TRAVIS_BRANCH/req-travis-pip.txt
-        pip install -e git+git://github.com/mila-udem/blocks.git@$TRAVIS_BRANCH#egg=blocks --src=$HOME -r https://raw.githubusercontent.com/mila-udem/blocks/$TRAVIS_BRANCH/requirements.txt
-      fi
-  - |
       if [[ $TESTS == 'fuel' ]]; then
         conda install -q --yes python=$TRAVIS_PYTHON_VERSION --file req-travis-conda.txt
         pip install -r req-travis-pip.txt
@@ -40,13 +32,6 @@ install:
 script:
   - ./.travis-data.sh adult mnist binarized_mnist "caltech101_silhouettes 16" cifar10 cifar100 iris ilsvrc2010
   - function fail { export FAILED=1; }
-  - |
-      if [[ $TESTS == 'blocks' ]]; then
-        bokeh-server &> /dev/null &
-        nose2 tests --start-dir $HOME/blocks || fail
-        nose2 doctests --start-dir $HOME/blocks || fail
-        return $FAILED
-      fi
   - |
       if [[ $TESTS == 'fuel' ]]; then
         # Running nose2 within coverage makes imports count towards coverage

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 .. image:: https://travis-ci.org/Scyfer/fuel.svg?branch=master
    :target: https://travis-ci.org/Scyfer/fuel
 
+.. image:: https://img.shields.io/badge/license-MIT-blue.svg       
+   :target: https://github.com/mila-udem/fuel/blob/master/LICENSE
+
 Fuel
 ====
 

--- a/README.rst
+++ b/README.rst
@@ -1,20 +1,5 @@
-.. image:: https://img.shields.io/coveralls/mila-udem/fuel.svg
-   :target: https://coveralls.io/r/mila-udem/fuel
-
-.. image:: https://travis-ci.org/mila-udem/fuel.svg?branch=master
-   :target: https://travis-ci.org/mila-udem/fuel
-
-.. image:: https://readthedocs.org/projects/fuel/badge/?version=latest
-   :target: https://fuel.readthedocs.org/
-
-.. image:: https://img.shields.io/scrutinizer/g/mila-udem/fuel.svg
-   :target: https://scrutinizer-ci.com/g/mila-udem/fuel/
-
-.. image:: https://requires.io/github/mila-udem/fuel/requirements.svg?branch=master
-   :target: https://requires.io/github/mila-udem/fuel/requirements/?branch=master
-
-.. image:: https://img.shields.io/badge/license-MIT-blue.svg
-   :target: https://github.com/mila-udem/fuel/blob/master/LICENSE
+.. image:: https://travis-ci.org/Scyfer/fuel.svg?branch=master
+   :target: https://travis-ci.org/Scyfer/fuel
 
 Fuel
 ====


### PR DESCRIPTION
Since we update the fork quite often, it's probably useful to have our own travis builds.

I still have to disable Blocks builds - we're primarily interested in fuel. 
