### PR TITLE
Fixed flip transformer that it keeps the axis labels.

### DIFF
--- a/fuel/transformers/image.py
+++ b/fuel/transformers/image.py
@@ -845,6 +845,7 @@ class RandomSpatialFlip(SourcewiseTransformer):
         if self.rng is None:
             self.rng = numpy.random.RandomState(config.default_seed)
         kwargs.setdefault('produces_examples', data_stream.produces_examples)
+        kwargs.setdefault('axis_labels', data_stream.axis_labels)
         super(RandomSpatialFlip, self).__init__(data_stream, **kwargs)
 
     def transform_source_example(self, source_example, source_name,


### PR DESCRIPTION
Flip transformer was not preserving the axis before. This bug fix will solve that.
