### PR TITLE
Use cythonize in setup.py

### DIFF
--- a/req-travis-conda.txt
+++ b/req-travis-conda.txt
@@ -1,3 +1,4 @@
+Cython==0.23.1
 coverage==4.0.3
 h5py==2.5.0
 mock==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from os import path
 import sys
 from setuptools import find_packages, setup
+from Cython.Build import cythonize
 from distutils.extension import Extension
 
 HERE = path.abspath(path.dirname(__file__))
@@ -44,8 +45,9 @@ setup(
     ],
     keywords='dataset data iteration pipeline processing',
     packages=find_packages(exclude=['tests']),
-    install_requires=['numpy', 'six', 'picklable_itertools', 'pyyaml', 'h5py', 'tables',
-                      'progressbar2', 'pyzmq', 'scipy', 'pillow', 'requests'],
+    install_requires=['numpy', 'six', 'picklable_itertools', 'pyyaml', 'h5py', 'cython', 
+                      'tables', 'progressbar2', 'pyzmq', 'scipy', 'pillow', 
+                      'requests'],
     extras_require={
         'test': ['mock', 'nose', 'nose2'],
         'docs': ['sphinx', 'sphinx-rtd-theme']
@@ -55,7 +57,7 @@ setup(
                             'fuel-download = fuel.bin.fuel_download:main',
                             'fuel-info = fuel.bin.fuel_info:main']
     },
-    #ext_modules=[Extension("fuel.transformers._image",
-    #                       ["fuel/transformers/_image.c"],
-    #                       extra_compile_args=extra_compile_args)]
+    ext_modules=cythonize(Extension("fuel.transformers._image",
+                                    ["fuel/transformers/_image.pyx"],
+                                    extra_compile_args=extra_compile_args))
 )


### PR DESCRIPTION
The cython image operations are often not compiled. This is probably due to `_image.pyx` not being cythonized in setup.

We need to investigate why we diverted from MILA here, as they seem to have included the `_image.c` file!
